### PR TITLE
Remove check on line 142

### DIFF
--- a/src/Reports/Report.php
+++ b/src/Reports/Report.php
@@ -139,9 +139,6 @@ class Report
         if(func_num_args() != 2)
             throw new \Edujugon\GoogleAds\Exceptions\Report('During clause only accepts 2 parameters. if dates, the format should be as follow: 20170112,20171020');
 
-        if( ! empty(preg_grep("/ /", $dates)) )
-            throw new \Edujugon\GoogleAds\Exceptions\Report('During clause only accepts the following format for dates: "Ymd" => e.g. 20170112,20171020');
-
         $this->during = func_get_args();
 
         return $this;


### PR DESCRIPTION
An array is not being passed in to the during function so you cannot use the preg_grep("/ /", $dates) function which requires an array.