### PR TITLE
use laravel's config() helper to get config

### DIFF
--- a/src/Support/helpers.php
+++ b/src/Support/helpers.php
@@ -51,19 +51,11 @@ function google_report_fields($session = null)
  */
 function e_ads_config()
 {
-    if(function_exists('config_path'))
-    {
-        if(file_exists(config_path('google-ads.php')))
-        {
-            $configuration = include(config_path('google-ads.php'));
-
-            return $configuration;
-        }
+    if (function_exists('config')) {
+        return config('google-ads');
     }
 
-    $configuration = include(__DIR__ . '/../Config/config.php');
-
-    return $configuration;
+    return include(__DIR__ . '/../Config/config.php');
 }
 
 /**


### PR DESCRIPTION
If you attempt to use environment vars loaded in your google-ads.php config file, you'll get an error when you cache the config (`php artisan config:cache`). 

addresses this issue: https://github.com/Edujugon/laravel-google-ads/issues/47

